### PR TITLE
Increment build and version numbers one patch-level-version for iOS and Android

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Convo Cards",
     "slug": "convo-cards",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -21,7 +21,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.connortyrrell.convocards",
-      "buildNumber": "4"
+      "buildNumber": "5"
     },
     "android": {
       "adaptiveIcon": {
@@ -29,7 +29,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.connortyrrell.convocards",
-      "versionCode": 4
+      "versionCode": 5
     },
     "web": {
       "favicon": "./assets/favicon.png"


### PR DESCRIPTION
Related to #1

Increment the build and version numbers one patch-level-version for iOS and Android.

* Increment the version number in `app.json` from "1.0.4" to "1.0.5".
* Increment the iOS build number in `app.json` from "4" to "5".
* Increment the Android version code in `app.json` from "4" to "5".


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/angusmccloud/convocards-app/issues/1?shareId=b8b41d13-83d8-4b7b-bfd8-9f099e6f6f75).